### PR TITLE
Build instructions (fixes #8)

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,3 +2,36 @@ Unbound Bible
 ===========
 
 The Unbound Bible is an open source and a free, multilingual Bible-reader program for Windows, macOS and Linux. This is fast and effective way to explore bibles.
+
+
+Build Instructions
+------------------
+
+(Tested under Linux.)
+
+Install ZeosDBO (see the [Lazarus wiki](https://wiki.freepascal.org/ZeosDBO) for full instructions):
+
+```bash
+$ cd components
+$ svn co http://svn.code.sf.net/p/zeoslib/code-0/trunk
+$ mv trunk zeosdb
+$ cd ..
+```
+
+Compile the dependent packages:
+
+```bash
+$ lazbuild components/zeosdb/packages/lazarus/zcomponent.lpk
+$ lazbuild components/richmemo/richmemopackage.lpk
+$ lazbuild components/unboundmemo/unboundmemopackage.lpk
+```
+
+Build unboundbible:
+
+```bash
+$ lazbuild unboundbible.lpr
+```
+
+The binary will be in the current folder.
+
+

--- a/unitmodule.pas
+++ b/unitmodule.pas
@@ -121,7 +121,7 @@ begin
     Connection := TZConnection.Create(nil);
     Query := TZReadOnlyQuery.Create(nil);
     Connection.Database := FilePath;
-    Connection.Protocol := 'sqlite-3';
+    Connection.Protocol := 'sqlite';
     Connection.AutoCommit := False;
     Query.Connection := Connection;
   {$else}


### PR DESCRIPTION
Instructions added for Lazarus command-line under Linux. 

Also includes a fix for ZeosDBO changes to their sqlite3  protocol string.

